### PR TITLE
Fix for kubernetes 1.17

### DIFF
--- a/device-plugin-ds.yaml
+++ b/device-plugin-ds.yaml
@@ -4,6 +4,11 @@ metadata:
   name: gpushare-device-plugin-ds
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+        component: gpushare-device-plugin
+        app: gpushare
+        name: gpushare-device-plugin-ds
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Similar issue here : https://github.com/Azure/aks-engine/issues/1573

Documentation : https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

In particular, `spec.selector` is now required and immutable after creation