### PR TITLE
fix: modify the naming method to reduce the gRPC's request bytes

### DIFF
--- a/pkg/gpu/nvidia/nvidia.go
+++ b/pkg/gpu/nvidia/nvidia.go
@@ -24,7 +24,7 @@ func check(err error) {
 }
 
 func generateFakeDeviceID(realID string, fakeCounter uint) string {
-	return fmt.Sprintf("%s-_-%d", realID, fakeCounter)
+	return fmt.Sprintf("FakeID-%s-%d", realID, fakeCounter)
 }
 
 func extractRealDeviceID(fakeDeviceID string) string {
@@ -71,7 +71,7 @@ func getDevices() ([]*pluginapi.Device, map[string]uint) {
 			setGPUMemory(uint(*d.Memory))
 		}
 		for j := uint(0); j < getGPUMemory(); j++ {
-			fakeID := generateFakeDeviceID(d.UUID, j)
+			fakeID := generateFakeDeviceID(i, j)
 			if j == 0 {
 				log.Infoln("# Add first device ID: " + fakeID)
 			}


### PR DESCRIPTION
MiB unit may reach gRPC package limit 4MiB

fix: #39 